### PR TITLE
Extend and modernize tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,11 +10,6 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
-[*.py]
-multi_line_output=5
-known_standard_library=mock
-known_first_party=patchy
-
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/patchy/api.py
+++ b/patchy/api.py
@@ -1,8 +1,8 @@
 # -*- encoding:utf-8 -*-
 import inspect
-import subprocess
 import os
 import shutil
+import subprocess
 from functools import wraps
 from tempfile import mkdtemp
 from textwrap import dedent
@@ -183,9 +183,11 @@ def _get_real_func(func):
     """
     if inspect.ismethod(func):
         try:
+            # Python 3:
             # classmethod, staticmethod
             real_func = func.__func__
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
+            # Python 2:
             real_func = func.im_func
     else:
         real_func = func

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
-six==1.10.0
+coverage==4.0.3
+docutils==0.12
+flake8==2.5.4
+isort==4.2.5
+mccabe==0.4.0
+pep8==1.7.0
+py==1.4.31
+pyflakes==1.1.0
+Pygments==2.1.3
+pytest-cov==2.2.1
 pytest==2.9.1
-twine
-wheel
+six==1.10.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+from lib2to3.main import main as lib2to3_main
+
+import pytest
+from flake8.main import main as flake8_main
+
+SOURCE_FILES = [
+    'patchy',
+    'tests',
+    'runtests.py',
+    'setup.py',
+]
+
+
+def main():
+    try:
+        sys.argv.remove('--nolint')
+    except ValueError:
+        run_lint = True
+    else:
+        run_lint = False
+
+    try:
+        sys.argv.remove('--lintonly')
+    except ValueError:
+        run_tests = True
+    else:
+        run_tests = False
+
+    if run_tests:
+        exit_on_failure(tests_main())
+
+    if run_lint:
+        exit_on_failure(run_flake8())
+        exit_on_failure(run_2to3())
+        exit_on_failure(run_isort())
+
+        # Broken on 2.7.9 due to http://bugs.python.org/issue23063
+        if sys.version_info[:3] != (2, 7, 9):
+            exit_on_failure(run_setup_py_check())
+
+
+def tests_main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    sys.path.insert(0, "tests")
+
+    # pytest was picking up test_utilities as a doctest
+    sys.argv.append("--ignore=docs")
+    return pytest.main()
+
+
+def run_flake8():
+    print('Running flake8 code linting')
+    try:
+        original_argv = sys.argv
+        sys.argv = ['flake8'] + SOURCE_FILES
+        did_fail = False
+        flake8_main()
+    except SystemExit:
+        did_fail = True
+    finally:
+        sys.argv = original_argv
+
+    print('flake8 failed' if did_fail else 'flake8 passed')
+    return did_fail
+
+
+def run_2to3():
+    print('Running 2to3 checks')
+    ret = lib2to3_main(
+        'lib2to3.fixes',
+        [
+            '-f', 'idioms',
+            '-f', 'isinstance',
+            '-f', 'set_literal',
+            '-f', 'tuple_params',
+            '-j', '4',
+        ] + SOURCE_FILES
+    )
+    print('2to3 failed' if ret else '2to3 passed')
+    return ret
+
+
+def run_isort():
+    print('Running isort check')
+    return subprocess.call(
+        ['isort', '--recursive', '--check-only', '--diff'] + SOURCE_FILES
+    )
+
+
+def run_setup_py_check():
+    print('Running setup.py check')
+    return subprocess.call([
+        'python', 'setup.py', 'check',
+        '-s', '--restructuredtext', '--metadata'
+    ])
+
+
+def exit_on_failure(ret, message=None):
+    if ret:
+        sys.exit(ret)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,12 @@
-[bdist_wheel]
+[isort]
+multi_line_output = 5
+known_standard_library = mock
+known_first_party = patchy
+
+[pytest]
+addopts = --cov=patchy
+          --cov-report term-missing
+          --cov-fail-under 100
+
+[wheel]
 universal = 1

--- a/tests/test_patchy.py
+++ b/tests/test_patchy.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function
 
-import six
 import unittest
 
 import pytest
+import six
 
 import patchy
 import patchy.api
+
 from .base import PatchyTestCase
+
+if six.PY3:
+    # For linting purposes only
+    unicode = None
 
 
 class PatchTests(PatchyTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,15 @@
 [tox]
-envlist = py27, py34, py35
+envlist =
+    py35-codestyle,
+    py{27,34,35}
 
 [testenv]
-commands = py.test {posargs}
-deps =
-    -r{toxinidir}/requirements.txt
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+install_command = pip install --no-deps {opts} {packages}
+deps = -r{toxinidir}/requirements.txt
+commands = ./runtests.py --nolint {posargs}
+
+
+[testenv:py35-codestyle]
+commands = ./runtests.py --lintonly


### PR DESCRIPTION
* Add `flake8`, `isort`, `setup.py check`
* Run linting as a separate tox env
* Fix violations
* Fix all dependencies to exact versions