### PR TITLE
Add replace()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Pending Release
 ---------------
 
 * (Insert new release notes below this line)
+* Added new function ``patchy.replace()``, that can be used to directly assign
+  new source code to a function, without having to make a patch.
 
 1.3.2 (2017-03-13)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -195,6 +195,27 @@ Decorator example, using the same ``sample`` and ``patch_text``:
     print(my_func())  # prints True
 
 
+``replace(func, new_source)``
+-----------------------------
+
+Replace the source code of function ``func`` with ``new_source``.
+This is highly unrecommended as it means if the original function changes,
+the call to replace() will continue to silently succeed.
+
+Example:
+
+.. code-block:: python
+
+    import patchy
+
+    def sample():
+        return 1
+
+    patchy.replace(sample, "def sample():\n return 42\n")
+
+    print(sample())  # prints 42
+
+
 How to Create a Patch
 =====================
 

--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ Decorator example, using the same ``sample`` and ``patch_text``:
 
 Replace the source code of function ``func`` with ``new_source``.
 This is highly unrecommended as it means if the original function changes,
-the call to replace() will continue to silently succeed.
+the call to ``replace()`` will continue to silently succeed.
 
 Example:
 

--- a/patchy/api.py
+++ b/patchy/api.py
@@ -15,7 +15,7 @@ import six
 
 from .cache import PatchingCache
 
-__all__ = ('patch', 'mc_patchface', 'unpatch', 'temp_patch')
+__all__ = ('patch', 'mc_patchface', 'unpatch', 'replace', 'temp_patch')
 
 
 # Public API
@@ -29,6 +29,10 @@ mc_patchface = patch
 
 def unpatch(func, patch_text):
     return _do_patch(func, patch_text, forwards=False)
+
+
+def replace(func, new_source):
+    _set_source(func, new_source)
 
 
 class temp_patch(object):

--- a/tests/test_patchy.py
+++ b/tests/test_patchy.py
@@ -39,6 +39,13 @@ class TestPatch(PatchyTestCase):
             """)
         assert sample() == 2
 
+    def test_replace(self):
+        def sample():
+            return 1
+
+        patchy.replace(sample, 'def sample():\n return 42\n')
+        assert sample() == 42
+
     def test_patch_simple_no_newline(self):
         def sample():
             return 1


### PR DESCRIPTION
This allows us to replace a function directly, without using a patch:

```python
import patchy

def foo():
        return 1

patchy.replace(foo, 'def foo():\n return 42\n')
```

Fixes #77