### PR TITLE
Add expected_source to replace()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,12 +195,26 @@ Decorator example, using the same ``sample`` and ``patch_text``:
     print(my_func())  # prints True
 
 
-``replace(func, new_source)``
------------------------------
+``replace(func, expected_source, new_source)``
+----------------------------------------------
 
-Replace the source code of function ``func`` with ``new_source``.
-This is highly unrecommended as it means if the original function changes,
-the call to ``replace()`` will continue to silently succeed.
+Check that ``func`` has an AST matching ``expected_source``, then replace its
+inner code object with source compiled from ``new_source``. If the AST check
+fails, ``ValueError`` will be raised with current/expected source code in the
+message. In the author's opinion it's preferable to call ``patch()`` so your
+call makes it clear to see what is being changed about ``func``, but using
+``replace()`` is simpler as you don't have to make a patch and there is no
+subprocess call to the ``patch`` utility.
+
+Note both ``expected_source`` and ``new_source`` will be
+``textwrap.dedent()``’ed, so the best way to include their source is with a
+triple quoted string with a backslash escape on the first line, as per the
+example below.
+
+If you want, you can pass ``expected_source=None`` to avoid the guard against
+your target changing, but this is highly unrecommended as it means if the
+original function changes, the call to ``replace()`` will continue to silently
+succeed.
 
 Example:
 
@@ -211,7 +225,17 @@ Example:
     def sample():
         return 1
 
-    patchy.replace(sample, "def sample():\n return 42\n")
+    patchy.replace(
+        sample,
+        """\
+        def sample():
+            return 1
+        """,
+        """\
+        def sample():
+            return 42
+        """
+    )
 
     print(sample())  # prints 42
 

--- a/tests/test_patchy.py
+++ b/tests/test_patchy.py
@@ -39,13 +39,6 @@ class TestPatch(PatchyTestCase):
             """)
         assert sample() == 2
 
-    def test_replace(self):
-        def sample():
-            return 1
-
-        patchy.replace(sample, 'def sample():\n return 42\n')
-        assert sample() == 42
-
     def test_patch_simple_no_newline(self):
         def sample():
             return 1
@@ -708,7 +701,7 @@ class TestUnpatch(PatchyTestCase):
         assert sample() == 1
 
 
-class TestBoth(PatchyTestCase):
+class TestPatchThenUnpatch(PatchyTestCase):
 
     def test_patch_unpatch(self):
         def sample():
@@ -784,3 +777,141 @@ class TestTempPatch(PatchyTestCase):
         assert sample() == 3456
         decorated()
         assert sample() == 3456
+
+
+class TestReplace(PatchyTestCase):
+
+    def test_replace(self):
+        def sample():
+            return 1
+
+        patchy.replace(
+            sample,
+            """\
+            def sample():
+                return 1
+            """,
+            """\
+            def sample():
+                return 42
+            """
+        )
+
+        assert sample() == 42
+
+    def test_replace_only_cares_about_ast(self):
+        def sample():
+            return 1
+
+        patchy.replace(
+            sample,
+            "def sample(): return 1",
+            "def sample(): return 42"
+        )
+
+        assert sample() == 42
+
+    def test_replace_twice(self):
+        def sample():
+            return 1
+
+        patchy.replace(
+            sample,
+            "def sample(): return 1",
+            "def sample(): return 2",
+        )
+        patchy.replace(
+            sample,
+            "def sample(): return 2",
+            "def sample(): return 3",
+        )
+
+        assert sample() == 3
+
+    def test_replace_mutable_default_arg(self):
+        def foo(append=None, mutable=[]):
+            if append is not None:
+                mutable.append(append)
+            return len(mutable)
+
+        assert foo() == 0
+        assert foo('v1') == 1
+        assert foo('v2') == 2
+        assert foo(mutable=[]) == 0
+
+        patchy.replace(
+            foo,
+            """\
+            def foo(append=None, mutable=[]):
+                if append is not None:
+                    mutable.append(append)
+                return len(mutable)
+            """,
+            """\
+            def foo(append=None, mutable=[]):
+                len(mutable)
+                if append is not None:
+                    mutable.append(append)
+                return len(mutable)
+            """
+        )
+
+        assert foo() == 2
+        assert foo('v3') == 3
+        assert foo(mutable=[]) == 0
+
+    def test_replace_instancemethod(self):
+        class Artist(object):
+            def method(self):
+                return 'Chalk'
+
+        patchy.replace(
+            Artist.method,
+            """\
+            def method(self):
+                return 'Chalk'
+            """,
+            """\
+            def method(self):
+                return 'Cheese'
+            """
+        )
+
+        assert Artist().method() == "Cheese"
+
+    def test_replace_unexpected_source(self):
+        def sample():
+            return 2
+
+        with pytest.raises(ValueError) as excinfo:
+            patchy.replace(
+                sample,
+                """\
+                def sample():
+                    return 1
+                """,
+                """\
+                def sample():
+                    return 42
+                """
+            )
+
+        msg = str(excinfo.value)
+        assert "The code of 'sample' has changed from expected" in msg
+        assert 'return 2' in msg
+        assert 'return 1' in msg
+
+    def test_replace_no_expected_source(self):
+        def sample():
+            return 2
+
+        patchy.replace(
+            sample,
+            None,
+            """\
+            def sample():
+                return 42
+            """
+        )
+
+        assert sample() == 42


### PR DESCRIPTION
As noted in review of #78, it would be best if there was a built-in way to guard against the target function changing, like `patch()` provides by default.

This has been added by doing an AST comparison between a provided (optional), `expected_source` argument, and the target function's source.