### PR TITLE
Don't set specific version of Python 3 in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,36}-codestyle,
-    py{27,36}
+    py{27,3},
+    py{27,3}-codestyle
 
 [testenv]
 setenv =
@@ -15,6 +15,6 @@ commands = pytest {posargs}
 skip_install = true
 commands = multilint --skip setup.py
 
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
This allows me to have Python 3.7 locally whilst 3.6 is used on Travis right now.