### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 1.5.0 (2019-02-15)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Use **pip**:
 
     pip install patchy
 
-Tested on Python 2.7 and 3.6.
+Python 3.4+ supported.
 
 
 Why?

--- a/patchy/api.py
+++ b/patchy/api.py
@@ -1,5 +1,4 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
+import __future__
 
 import ast
 import inspect
@@ -10,8 +9,6 @@ from functools import wraps
 from tempfile import mkdtemp
 from textwrap import dedent
 from weakref import WeakKeyDictionary
-
-import six
 
 from .cache import PatchingCache
 
@@ -70,7 +67,7 @@ def _dot_lookup(thing, comp, import_path):
 
 
 def _importer(target):
-    if not isinstance(target, six.string_types):
+    if not isinstance(target, str):
         return target
 
     components = target.split('.')
@@ -157,7 +154,6 @@ def _apply_patch(source, patch_text, forwards, name):
 
 
 def _get_flags_mask():
-    import __future__
     result = 0
     for name in __future__.all_feature_names:
         result |= getattr(__future__, name).compiler_flag
@@ -307,7 +303,7 @@ def _set_source(func, func_source):
     localz = {}
     new_code = _compile(new_source)
 
-    six.exec_(new_code, dict(func.__globals__), localz)
+    exec(new_code, dict(func.__globals__), localz)
     new_func = localz['__patchy_freevars__']()
 
     # Figure out how to get the Code object

--- a/patchy/cache.py
+++ b/patchy/cache.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import random
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,8 @@
 docutils
 flake8
-futures<3.2.0
 isort
-modernize
 multilint
 pytest
 pytest-cov
 pytest-env-info
 Pygments
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,20 +6,13 @@
 #
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-backports.functools-lru-cache==1.5 ; python_version < '3.0' # via isort
-configparser==3.7.4       # via entrypoints, flake8
 coverage==4.5.3           # via pytest-cov
 docutils==0.14
 entrypoints==0.3          # via flake8
-enum34==1.1.6             # via flake8
 flake8==3.7.7
-funcsigs==1.0.2           # via pytest
-functools32==3.2.3.post2  ; python_version < '3.0' # via flake8
-futures==3.1.1
 isort==4.3.18
 mccabe==0.6.1             # via flake8
-modernize==0.7
-more-itertools==5.0.0     # via pytest
+more-itertools==7.0.0     # via pytest
 multilint==2.4.0
 pathlib2==2.3.3           # via pytest
 pluggy==0.11.0            # via pytest
@@ -29,7 +22,5 @@ pyflakes==2.1.1           # via flake8
 pygments==2.4.0
 pytest-cov==2.7.1
 pytest-env-info==0.3.0
-pytest==4.4.1
-scandir==1.10.0           # via pathlib2
-six==1.12.0
-typing==3.6.6             # via flake8
+pytest==4.4.2
+six==1.12.0               # via multilint, pathlib2, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max_line_length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import os
 import re
 
@@ -9,17 +5,17 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version(os.path.join('patchy', '__init__.py'))
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
@@ -33,10 +29,8 @@ setup(
     url='https://github.com/adamchainz/patchy',
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
-    install_requires=[
-        'six>=1.9.0',
-    ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    install_requires=[],
+    python_requires='>=3.4.*',
     license="BSD",
     zip_safe=False,
     keywords='patchy',
@@ -46,8 +40,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,4 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
-import six
 
 import patchy.api
 
@@ -10,7 +6,3 @@ import patchy.api
 @pytest.fixture(autouse=True)
 def clear_cache():
     patchy.api._patching_cache.clear()
-
-
-skip_unless_python_2 = pytest.mark.skipif(not six.PY2, reason="Python 2 only")
-skip_unless_python_3 = pytest.mark.skipif(not six.PY3, reason="Python 3 only")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 from patchy.cache import PatchingCache

--- a/tests/test_patch_then_unpatch.py
+++ b/tests/test_patch_then_unpatch.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import patchy
 import patchy.api
 

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 import patchy

--- a/tests/test_temp_patch.py
+++ b/tests/test_temp_patch.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from textwrap import dedent
 

--- a/tests/test_unpatch.py
+++ b/tests/test_unpatch.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 import patchy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,3},
-    py{27,3}-codestyle
+    py3,
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -9,11 +9,6 @@ setenv =
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 commands = pytest {posargs}
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* Remove `skip_unless_python_2` and `skip_unless_python_3` test decorators
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove universal wheel building