### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ Patchy
 .. image:: https://img.shields.io/pypi/v/patchy.svg
         :target: https://pypi.python.org/pypi/patchy
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 .. figure:: https://raw.github.com/adamchainz/patchy/master/pirate.png
    :alt: A patchy pirate.
 

--- a/patchy/__init__.py
+++ b/patchy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from .api import *  # noqa
 
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '1.5.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "1.5.0"

--- a/patchy/cache.py
+++ b/patchy/cache.py
@@ -22,5 +22,5 @@ class PatchingCache(object):
 
         # Cache in both directions - makes reversal faster
         self._cache[(source, patch_text, forwards)] = new_source
-        other_direction = (not forwards)
+        other_direction = not forwards
         self._cache[(new_source, patch_text, other_direction)] = source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -65,6 +65,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -65,6 +65,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./requirements-compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -65,6 +76,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -146,6 +160,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
+flake8-bugbear
 isort
 multilint
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,16 @@
 [flake8]
-max_line_length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
+include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = patchy
-known_standard_library = mock
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -5,44 +5,44 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version(os.path.join('patchy', '__init__.py'))
+version = get_version(os.path.join("patchy", "__init__.py"))
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 
 setup(
-    name='patchy',
+    name="patchy",
     version=version,
     description="Patch the inner source of python functions at runtime.",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/patchy',
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/patchy",
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     install_requires=[],
-    python_requires='>=3.5.*',
+    python_requires=">=3.5.*",
     license="BSD",
     zip_safe=False,
-    keywords='patchy',
+    keywords="patchy",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -14,12 +14,15 @@ def test_patch():
     def sample():
         return 1
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def sample():
         -    return 1
         +    return 9001
-        """)
+        """,
+    )
     assert sample() == 9001
 
 
@@ -27,11 +30,14 @@ def test_mc_patchface():
     def sample():
         return 1
 
-    patchy.mc_patchface(sample, """\
+    patchy.mc_patchface(
+        sample,
+        """\
         @@ -2,2 +2,2 @@
         -    return 1
         +    return 2
-        """)
+        """,
+    )
     assert sample() == 2
 
 
@@ -39,10 +45,13 @@ def test_patch_simple_no_newline():
     def sample():
         return 1
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -2,2 +2,2 @@
         -    return 1
-        +    return 2""")
+        +    return 2""",
+    )
     assert sample() == 2
 
 
@@ -50,6 +59,7 @@ def test_patch_invalid():
     """
     We need to balk on empty patches
     """
+
     def sample():
         return 1
 
@@ -59,7 +69,8 @@ def test_patch_invalid():
         patchy.patch(sample, bad_patch)
 
     msg = str(excinfo.value)
-    expected = dedent("""\
+    expected = dedent(
+        """\
         Could not apply the patch to 'sample'. The message from `patch` was:
 
         patch: **** Only garbage was found in the patch input.
@@ -70,7 +81,8 @@ def test_patch_invalid():
 
         The patch was:
         garbage
-    """)
+    """
+    )
     assert msg == expected
     assert sample() == 1
 
@@ -79,6 +91,7 @@ def test_patch_invalid_hunk():
     """
     We need to balk on patches that fail on application
     """
+
     def sample():
         return 1
 
@@ -98,6 +111,7 @@ def test_patch_invalid_hunk_2():
     """
     We need to balk on patches that fail on application
     """
+
     def sample():
         if True:
             print("yes")
@@ -127,75 +141,90 @@ def test_patch_twice():
     def sample():
         return 1
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def sample():
         -    return 1
-        +    return 2""")
-    patchy.patch(sample, """\
+        +    return 2""",
+    )
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def sample():
         -    return 2
         +    return 3
-        """)
+        """,
+    )
 
     assert sample() == 3
 
 
 def test_patch_mutable_default_arg():
-    def foo(append=None, mutable=[]):
+    def foo(append=None, mutable=[]):  # noqa: B006
         if append is not None:
             mutable.append(append)
         return len(mutable)
 
     assert foo() == 0
-    assert foo('v1') == 1
-    assert foo('v2') == 2
+    assert foo("v1") == 1
+    assert foo("v2") == 2
     assert foo(mutable=[]) == 0
 
-    patchy.patch(foo, """\
+    patchy.patch(
+        foo,
+        """\
         @@ -1,2 +1,3 @@
          def foo(append=None, mutable=[]):
         +    len(mutable)
              if append is not None:
-        """)
+        """,
+    )
 
     assert foo() == 2
-    assert foo('v3') == 3
+    assert foo("v3") == 3
     assert foo(mutable=[]) == 0
 
 
 def test_patch_instancemethod():
     class Artist(object):
         def method(self):
-            return 'Chalk'
+            return "Chalk"
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    return 'Chalk'
-        +    return 'Cheese'
-        """)
+        -    return "Chalk"
+        +    return "Cheese"
+        """,
+    )
 
     assert Artist().method() == "Cheese"
 
 
 def test_patch_instancemethod_freevars():
     def free_func(v):
-        return v + ' on toast'
+        return v + " on toast"
 
     class Artist:
         def method(self):
-            filling = 'Chalk'
+            filling = "Chalk"
             return free_func(filling)
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    filling = 'Chalk'
-        +    filling = 'Cheese'
+        -    filling = "Chalk"
+        +    filling = "Cheese"
              return free_func(filling)
-        """)
+        """,
+    )
 
     assert Artist().method() == "Cheese on toast"
 
@@ -205,8 +234,10 @@ def test_patch_init_module_level(tmpdir):
     Module level classes do not have a freevar for their class name, whilst
     classes defined in a scope do...
     """
-    example_py = tmpdir.join('patch_init_module_level.py')
-    example_py.write(dedent('''\
+    example_py = tmpdir.join("patch_init_module_level.py")
+    example_py.write(
+        dedent(
+            """\
         class Person(object):
             def __init__(self):
                 self.base_prop = 'yo'
@@ -216,22 +247,27 @@ def test_patch_init_module_level(tmpdir):
             def __init__(self):
                 super(Artist, self).__init__()
                 self.prop = 'old'
-    '''))
+    """
+        )
+    )
     mod = example_py.pyimport()
     Artist = mod.Artist
 
-    patchy.patch(Artist.__init__, """\
+    patchy.patch(
+        Artist.__init__,
+        """\
         @@ -1,3 +1,3 @@
          def __init__(self):
              super(Artist, self).__init__()
         -    self.prop = 'old'
         +    self.prop = 'new'
-    """)
+    """,
+    )
 
     a = Artist()
     assert mod.Artist == Artist
-    assert a.base_prop == 'yo'
-    assert a.prop == 'new'
+    assert a.base_prop == "yo"
+    assert a.prop == "new"
 
 
 def test_patch_recursive_module_level(tmpdir):
@@ -239,20 +275,26 @@ def test_patch_recursive_module_level(tmpdir):
     Module level recursive functions do not have a freevar for their name,
     whilst functions defined in a scope do...
     """
-    example_py = tmpdir.join('patch_recursive_module_level.py')
-    example_py.write(dedent("""\
+    example_py = tmpdir.join("patch_recursive_module_level.py")
+    example_py.write(
+        dedent(
+            """\
         def factorial(n):
             if n == 1:
                 return 1
             else:
                 return n * factorial(n-1)
-    """))
+    """
+        )
+    )
     mod = example_py.pyimport()
     factorial = mod.factorial
 
     assert factorial(10) == 3628800
 
-    patchy.patch(factorial, """\
+    patchy.patch(
+        factorial,
+        """\
         @@ -2,4 +2,4 @@
         -    if n == 1:
         -        return 1
@@ -262,7 +304,8 @@ def test_patch_recursive_module_level(tmpdir):
         +       return n
         +   else:
         +       return factorial(n-1) + factorial(n-2)
-    """)
+    """,
+    )
 
     assert factorial(10) == 55
     assert factorial == mod.factorial
@@ -271,116 +314,120 @@ def test_patch_recursive_module_level(tmpdir):
 def test_patch_init_super_new():
     class Person(object):
         def __init__(self):
-            self.base_prop = 'yo'
+            self.base_prop = "yo"
 
     class Artist(Person):
         def __init__(self):
             super().__init__()
-            self.prop = 'old'
+            self.prop = "old"
 
-    patchy.patch(Artist.__init__, """\
+    patchy.patch(
+        Artist.__init__,
+        """\
         @@ -1,3 +1,3 @@
          def __init__(self):
              super().__init__()
-        -    self.prop = 'old'
-        +    self.prop = 'new'""")
+        -    self.prop = "old"
+        +    self.prop = "new"
+        """,
+    )
 
     a = Artist()
-    assert a.base_prop == 'yo'
-    assert a.prop == 'new'
+    assert a.base_prop == "yo"
+    assert a.prop == "new"
 
 
 def test_patch_freevars():
     def free_func(v):
-        return v + ' on toast'
+        return v + " on toast"
 
     def sample():
-        filling = 'Chalk'
+        filling = "Chalk"
         return free_func(filling)
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def method():
-        -    filling = 'Chalk'
-        +    filling = 'Cheese'
+        -    filling = "Chalk"
+        +    filling = "Cheese"
              return free_func(filling)
-        """)
+        """,
+    )
 
     assert sample() == "Cheese on toast"
 
 
 def test_patch_freevars_order():
     def tastes_good(v):
-        return v + ' tastes good'
+        return v + " tastes good"
 
     def tastes_bad(v):
-        return v + ' tastes bad'
+        return v + " tastes bad"
 
     def sample():
-        return ', '.join([
-            tastes_good('Cheese'),
-            tastes_bad('Chalk'),
-        ])
+        return ", ".join([tastes_good("Cheese"), tastes_bad("Chalk")])
 
-    patchy.patch(sample, """\
-        @@ -1,4 +1,4 @@
+    patchy.patch(
+        sample,
+        """\
+        @@ -1,2 +1,2 @@
          def sample():
-             return ', '.join([
-        -        tastes_good('Cheese'),
-        -        tastes_bad('Chalk'),
-        +        tastes_bad('Chalk'),
-        +        tastes_good('Cheese'),
-             )]
-        """)
+        -    return ", ".join([tastes_good("Cheese"), tastes_bad("Chalk")])
+        +    return ", ".join([tastes_bad("Chalk"), tastes_good("Cheese")])
+        """,
+    )
 
-    assert sample() == 'Chalk tastes bad, Cheese tastes good'
+    assert sample() == "Chalk tastes bad, Cheese tastes good"
 
 
 def test_patch_freevars_remove():
     def tastes_good(v):
-        return v + ' tastes good'
+        return v + " tastes good"
 
     def tastes_bad(v):
-        return v + ' tastes bad'
+        return v + " tastes bad"
 
     def sample():
-        return ', '.join([
-            tastes_bad('Chalk'),
-            tastes_good('Cheese'),
-        ])
+        return ", ".join([tastes_bad("Chalk"), tastes_good("Cheese")])
 
-    patchy.patch(sample, """\
-        @@ -1,5 +1,4 @@
+    patchy.patch(
+        sample,
+        """\
+        @@ -1,2 +1,2 @@
          def sample():
-             return ', '.join([
-        -        tastes_bad('Chalk'),
-                 tastes_good('Cheese'),
-             ])
-        """)
+        -    return ", ".join([tastes_bad("Chalk"), tastes_good("Cheese")])
+        +    return ", ".join([tastes_good("Cheese")])
+        """,
+    )
 
-    assert sample() == 'Cheese tastes good'
+    assert sample() == "Cheese tastes good"
 
 
 def test_patch_freevars_nested():
     def free_func(v):
-        return v + ' on toast'
+        return v + " on toast"
 
     def sample():
-        filling = 'Chalk'
+        filling = "Chalk"
 
         def _inner_func():
             return free_func(filling)
 
         return _inner_func
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def sample():
-        -    filling = 'Chalk'
-        +    filling = 'Cheese'
+        -    filling = "Chalk"
+        +    filling = "Cheese"
 
              def _inner_func():
-        """)
+        """,
+    )
 
     assert sample()() == "Cheese on toast"
 
@@ -388,22 +435,25 @@ def test_patch_freevars_nested():
 @pytest.mark.xfail(raises=NameError)
 def test_patch_freevars_re_close():
     def nasty_filling(v):
-        return 'Chalk'
+        return "Chalk"
 
     def nice_filling(v):
-        return 'Cheese'
+        return "Cheese"
 
     def sample():
         filling = nasty_filling()
-        return filling + ' on toast'
+        return filling + " on toast"
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def sample():
         -    filling = nasty_filling()
         +    filling = nice_filling()
              return filling + ' on toast'
-        """)
+        """,
+    )
 
     assert sample() == "Cheese on toast"
 
@@ -411,19 +461,27 @@ def test_patch_freevars_re_close():
 def test_patch_instancemethod_twice():
     class Artist(object):
         def method(self):
-            return 'Chalk'
+            return "Chalk"
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    return 'Chalk'
-        +    return 'Cheese'""")
+        -    return "Chalk"
+        +    return "Cheese"
+        """,
+    )
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    return 'Cheese'
-        +    return 'Crackers'""")
+        -    return "Cheese"
+        +    return "Crackers"
+        """,
+    )
 
     assert Artist().method() == "Crackers"
 
@@ -431,19 +489,22 @@ def test_patch_instancemethod_twice():
 def test_patch_instancemethod_mangled():
     class Artist(object):
         def __mangled_name(self, v):
-            return v + ' on toast'
+            return v + " on toast"
 
         def method(self):
-            filling = 'Chalk'
+            filling = "Chalk"
             return self.__mangled_name(filling)
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    filling = 'Chalk'
-        +    filling = 'Cheese'
+        -    filling = "Chalk"
+        +    filling = "Cheese"
              return self.__mangled_name(filling)
-        """)
+        """,
+    )
 
     assert Artist().method() == "Cheese on toast"
 
@@ -451,48 +512,56 @@ def test_patch_instancemethod_mangled():
 def test_patch_old_class_instancemethod_mangled():
     class Artist:
         def __mangled_name(self, v):
-            return v + ' on toast'
+            return v + " on toast"
 
         def method(self):
-            filling = 'Chalk'
+            filling = "Chalk"
             return self.__mangled_name(filling)
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    filling = 'Chalk'
-        +    filling = 'Cheese'
+        -    filling = "Chalk"
+        +    filling = "Cheese"
              return self.__mangled_name(filling)
-        """)
+        """,
+    )
 
     assert Artist().method() == "Cheese on toast"
 
 
 def test_patch_instancemethod_mangled_freevars():
     def _Artist__mangled_name(v):
-        return v + ' on '
+        return v + " on "
 
     def plain_name(v):
-        return v + 'toast'
+        return v + "toast"
 
     class Artist:
         def method(self):
-            filling = 'Chalk'
+            filling = "Chalk"
             return plain_name(__mangled_name(filling))  # noqa: F821
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
-        -    filling = 'Chalk'
-        +    filling = 'Cheese'
+        -    filling = "Chalk"
+        +    filling = "Cheese"
              return plain_name(__mangled_name(filling))  # noqa: F821
-        """)
+        """,
+    )
 
     assert Artist().method() == "Cheese on toast"
 
 
 def test_patch_instancemethod_mangled_tabs(tmpdir):
-    tmpdir.join('tabs_mangled.py').write(dedent("""\
+    tmpdir.join("tabs_mangled.py").write(
+        dedent(
+            """\
         class Artist:
         \tdef __mangled_name(self, v):
         \t\treturn v + ' on toast'
@@ -500,7 +569,9 @@ def test_patch_instancemethod_mangled_tabs(tmpdir):
         \tdef method(self):
         \t\tfilling = 'Chalk'
         \t\treturn self.__mangled_name(filling)
-    """))
+    """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
 
     try:
@@ -508,13 +579,16 @@ def test_patch_instancemethod_mangled_tabs(tmpdir):
     finally:
         sys.path.pop(0)
 
-    patchy.patch(Artist.method, """\
+    patchy.patch(
+        Artist.method,
+        """\
         @@ -1,2 +1,2 @@
          def method(self):
         -\tfilling = 'Chalk'
         +\tfilling = 'Cheese'
         \treturn __mangled_name(filling)
-        """)
+        """,
+    )
 
     assert Artist().method() == "Cheese on toast"
 
@@ -522,32 +596,40 @@ def test_patch_instancemethod_mangled_tabs(tmpdir):
 def test_patch_init():
     class Artist(object):
         def __init__(self):
-            self.prop = 'old'
+            self.prop = "old"
 
-    patchy.patch(Artist.__init__, """\
+    patchy.patch(
+        Artist.__init__,
+        """\
         @@ -1,2 +1,2 @@
          def __init__(self):
-        -    self.prop = 'old'
-        +    self.prop = 'new'""")
+        -    self.prop = "old"
+        +    self.prop = "new"
+        """,
+    )
 
     a = Artist()
-    assert a.prop == 'new'
+    assert a.prop == "new"
 
 
 def test_patch_init_change_arg():
     class Artist(object):
         def __init__(self):
-            self.prop = 'old'
+            self.prop = "old"
 
-    patchy.patch(Artist.__init__, """\
+    patchy.patch(
+        Artist.__init__,
+        """\
         @@ -1,2 +1,2 @@
         -def __init__(self):
-        -    self.prop = 'old'
+        -    self.prop = "old"
         +def __init__(self, arg):
-        +    self.prop = arg""")
+        +    self.prop = arg
+        """,
+    )
 
-    a = Artist('new')
-    assert a.prop == 'new'
+    a = Artist("new")
+    assert a.prop == "new"
 
 
 def test_patch_classmethod():
@@ -559,12 +641,15 @@ def test_patch_classmethod():
         def create(cls, name):
             return cls(name)
 
-    patchy.patch(Emotion.create, """\
+    patchy.patch(
+        Emotion.create,
+        """\
         @@ -1,2 +1,3 @@
          @classmethod
          def create(cls, name):
         +    name = name.title()
-             return cls(name)""")
+             return cls(name)""",
+    )
 
     assert Emotion.create("Happy").name == "Happy"
     assert Emotion.create("happy").name == "Happy"
@@ -579,20 +664,26 @@ def test_patch_classmethod_twice():
         def create(cls, name):
             return cls(name)
 
-    patchy.patch(Emotion.create, """\
+    patchy.patch(
+        Emotion.create,
+        """\
         @@ -1,2 +1,3 @@
          @classmethod
          def create(cls, name):
         +    name = name.title()
-             return cls(name)""")
+             return cls(name)""",
+    )
 
-    patchy.patch(Emotion.create, """\
+    patchy.patch(
+        Emotion.create,
+        """\
         @@ -1,3 +1,3 @@
          @classmethod
          def create(cls, name):
         -    name = name.title()
         +    name = name.lower()
-             return cls(name)""")
+             return cls(name)""",
+    )
 
     assert Emotion.create("happy").name == "happy"
     assert Emotion.create("Happy").name == "happy"
@@ -605,12 +696,15 @@ def test_patch_staticmethod():
         def bark():
             return "Woof"
 
-    patchy.patch(Doge.bark, """\
+    patchy.patch(
+        Doge.bark,
+        """\
         @@ -1,3 +1,3 @@
          @staticmethod
          def bark():
         -    return "Woof"
-        +    return "Wow\"""")
+        +    return "Wow\"""",
+    )
 
     assert Doge.bark() == "Wow"
 
@@ -621,26 +715,36 @@ def test_patch_staticmethod_twice():
         def bark():
             return "Woof"
 
-    patchy.patch(Doge.bark, """\
+    patchy.patch(
+        Doge.bark,
+        """\
         @@ -1,3 +1,3 @@
          @staticmethod
          def bark():
         -    return "Woof"
-        +    return "Wow\"""")
+        +    return "Wow\"""",
+    )
 
-    patchy.patch(Doge.bark, """\
+    patchy.patch(
+        Doge.bark,
+        """\
         @@ -1,3 +1,3 @@
          @staticmethod
          def bark():
         -    return "Wow"
-        +    return "Wowowow\"""")
+        +    return "Wowowow\"""",
+    )
 
     assert Doge.bark() == "Wowowow"
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 7), reason="generator_stop made mandatory in Python 3.7")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 7), reason="generator_stop made mandatory in Python 3.7"
+)
 def test_patch_future_python_3_5_to_3_7(tmpdir):
-    tmpdir.join('future_user.py').write(dedent("""\
+    tmpdir.join("future_user.py").write(
+        dedent(
+            """\
         from __future__ import generator_stop
 
         def f(x):
@@ -649,7 +753,9 @@ def test_patch_future_python_3_5_to_3_7(tmpdir):
 
         def sample():
             return list(f(x) for x in range(10))
-    """))
+    """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
 
     try:
@@ -660,26 +766,35 @@ def test_patch_future_python_3_5_to_3_7(tmpdir):
     with pytest.raises(RuntimeError):
         sample()
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,3 @@
          def sample():
         +    pass
              return list(f(x) for x in range(10))
-        """)
+        """,
+    )
 
     with pytest.raises(RuntimeError):
         sample()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="__future__.annotations introduced in Python 3.7")
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="__future__.annotations introduced in Python 3.7"
+)
 def test_patch_future_python_3_7_plus(tmpdir):
-    tmpdir.join('future_user.py').write(dedent("""\
+    tmpdir.join("future_user.py").write(
+        dedent(
+            """\
         from __future__ import annotations
 
 
         def sample():
             pass
-    """))
+    """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
 
     try:
@@ -689,19 +804,26 @@ def test_patch_future_python_3_7_plus(tmpdir):
 
     assert sample.__code__.co_flags & __future__.annotations.compiler_flag
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -1,2 +1,3 @@
          def sample():
         +    pass
              pass
-        """)
+        """,
+    )
 
     assert sample.__code__.co_flags & __future__.annotations.compiler_flag
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 7), reason="generator_stop made mandatory in Python 3.7")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 7), reason="generator_stop made mandatory in Python 3.7"
+)
 def test_patch_future_instancemethod_python_3_5_to_3_7(tmpdir):
-    tmpdir.join('future_instancemethod.py').write(dedent("""\
+    tmpdir.join("future_instancemethod.py").write(
+        dedent(
+            """\
         from __future__ import generator_stop
 
         def f(x):
@@ -710,7 +832,9 @@ def test_patch_future_instancemethod_python_3_5_to_3_7(tmpdir):
         class Sample(object):
             def meth(self):
                 return list(f(x) for x in range(10))
-    """))
+    """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
 
     try:
@@ -721,26 +845,35 @@ def test_patch_future_instancemethod_python_3_5_to_3_7(tmpdir):
     with pytest.raises(RuntimeError):
         Sample().meth()
 
-    patchy.patch(Sample.meth, """\
+    patchy.patch(
+        Sample.meth,
+        """\
         @@ -1,2 +1,3 @@
          def meth(self):
         +    pass
              return list(f(x) for x in range(10))
-        """)
+        """,
+    )
 
     with pytest.raises(RuntimeError):
         Sample().meth()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="__future__.annotations introduced in Python 3.7")
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="__future__.annotations introduced in Python 3.7"
+)
 def test_patch_future_instancemethod_python_3_7_plus(tmpdir):
-    tmpdir.join('future_instancemethod.py').write(dedent("""\
+    tmpdir.join("future_instancemethod.py").write(
+        dedent(
+            """\
         from __future__ import annotations
 
         class Sample(object):
             def meth(self):
                 pass
-    """))
+    """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
 
     try:
@@ -750,19 +883,24 @@ def test_patch_future_instancemethod_python_3_7_plus(tmpdir):
 
     assert Sample.meth.__code__.co_flags & __future__.annotations.compiler_flag
 
-    patchy.patch(Sample.meth, """\
+    patchy.patch(
+        Sample.meth,
+        """\
         @@ -1,2 +1,3 @@
          def meth(self):
         +    pass
              pass
-        """)
+        """,
+    )
 
     assert Sample.meth.__code__.co_flags & __future__.annotations.compiler_flag
 
 
 def test_patch_nonlocal_fails(tmpdir):
     # Put in separate file since it would SyntaxError on Python 2
-    tmpdir.join('py3_nonlocal.py').write(dedent("""\
+    tmpdir.join("py3_nonlocal.py").write(
+        dedent(
+            """\
         variab = 20
 
 
@@ -777,7 +915,9 @@ def test_patch_nonlocal_fails(tmpdir):
             return sample
 
         sample = get_function()
-    """))
+    """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
     try:
         from py3_nonlocal import sample
@@ -786,31 +926,41 @@ def test_patch_nonlocal_fails(tmpdir):
 
     assert sample() == 15 * 3
 
-    patchy.patch(sample, """\
+    patchy.patch(
+        sample,
+        """\
         @@ -2,3 +2,3 @@
              nonlocal variab
         -    multiple = 3
         +    multiple = 4
-        """)
+        """,
+    )
 
     assert sample() == 15 * 4
 
 
 def test_patch_by_path(tmpdir):
-    package = tmpdir.mkdir('patch_by_path_pkg')
-    package.join('__init__.py').ensure(file=True)
-    package.join('mod.py').write(dedent("""\
+    package = tmpdir.mkdir("patch_by_path_pkg")
+    package.join("__init__.py").ensure(file=True)
+    package.join("mod.py").write(
+        dedent(
+            """\
         class Foo(object):
             def sample(self):
                 return 1
-        """))
+        """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
     try:
-        patchy.patch('patch_by_path_pkg.mod.Foo.sample', """\
+        patchy.patch(
+            "patch_by_path_pkg.mod.Foo.sample",
+            """\
             @@ -2,2 +2,2 @@
             -    return 1
             +    return 2
-            """)
+            """,
+        )
         from patch_by_path_pkg.mod import Foo
     finally:
         sys.path.pop(0)
@@ -819,22 +969,30 @@ def test_patch_by_path(tmpdir):
 
 
 def test_patch_by_path_already_imported(tmpdir):
-    package = tmpdir.mkdir('patch_by_path_pkg2')
-    package.join('__init__.py').ensure(file=True)
-    package.join('mod.py').write(dedent("""\
+    package = tmpdir.mkdir("patch_by_path_pkg2")
+    package.join("__init__.py").ensure(file=True)
+    package.join("mod.py").write(
+        dedent(
+            """\
         class Foo(object):
             def sample(self):
                 return 1
-        """))
+        """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
     try:
         from patch_by_path_pkg2.mod import Foo
+
         assert Foo().sample() == 1
-        patchy.patch('patch_by_path_pkg2.mod.Foo.sample', """\
+        patchy.patch(
+            "patch_by_path_pkg2.mod.Foo.sample",
+            """\
             @@ -2,2 +2,2 @@
             -    return 1
             +    return 2
-            """)
+            """,
+        )
     finally:
         sys.path.pop(0)
 

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -17,7 +17,7 @@ def test_replace():
         """\
         def sample():
             return 42
-        """
+        """,
     )
 
     assert sample() == 42
@@ -27,11 +27,7 @@ def test_replace_only_cares_about_ast():
     def sample():
         return 1
 
-    patchy.replace(
-        sample,
-        "def sample(): return 1",
-        "def sample(): return 42"
-    )
+    patchy.replace(sample, "def sample(): return 1", "def sample(): return 42")
 
     assert sample() == 42
 
@@ -40,29 +36,21 @@ def test_replace_twice():
     def sample():
         return 1
 
-    patchy.replace(
-        sample,
-        "def sample(): return 1",
-        "def sample(): return 2",
-    )
-    patchy.replace(
-        sample,
-        "def sample(): return 2",
-        "def sample(): return 3",
-    )
+    patchy.replace(sample, "def sample(): return 1", "def sample(): return 2")
+    patchy.replace(sample, "def sample(): return 2", "def sample(): return 3")
 
     assert sample() == 3
 
 
 def test_replace_mutable_default_arg():
-    def foo(append=None, mutable=[]):
+    def foo(append=None, mutable=[]):  # noqa: B006
         if append is not None:
             mutable.append(append)
         return len(mutable)
 
     assert foo() == 0
-    assert foo('v1') == 1
-    assert foo('v2') == 2
+    assert foo("v1") == 1
+    assert foo("v2") == 2
     assert foo(mutable=[]) == 0
 
     patchy.replace(
@@ -79,18 +67,18 @@ def test_replace_mutable_default_arg():
             if append is not None:
                 mutable.append(append)
             return len(mutable)
-        """
+        """,
     )
 
     assert foo() == 2
-    assert foo('v3') == 3
+    assert foo("v3") == 3
     assert foo(mutable=[]) == 0
 
 
 def test_replace_instancemethod():
     class Artist(object):
         def method(self):
-            return 'Chalk'
+            return "Chalk"
 
     patchy.replace(
         Artist.method,
@@ -101,7 +89,7 @@ def test_replace_instancemethod():
         """\
         def method(self):
             return 'Cheese'
-        """
+        """,
     )
 
     assert Artist().method() == "Cheese"
@@ -121,13 +109,13 @@ def test_replace_unexpected_source():
             """\
             def sample():
                 return 42
-            """
+            """,
         )
 
     msg = str(excinfo.value)
     assert "The code of 'sample' has changed from expected" in msg
-    assert 'return 2' in msg
-    assert 'return 1' in msg
+    assert "return 2" in msg
+    assert "return 1" in msg
 
 
 def test_replace_no_expected_source():
@@ -140,7 +128,7 @@ def test_replace_no_expected_source():
         """\
         def sample():
             return 42
-        """
+        """,
     )
 
     assert sample() == 42

--- a/tests/test_temp_patch.py
+++ b/tests/test_temp_patch.py
@@ -45,13 +45,17 @@ def test_decorator():
 
 
 def test_patch_by_path(tmpdir):
-    package = tmpdir.mkdir('tmp_by_path_pkg')
-    package.join('__init__.py').ensure(file=True)
-    package.join('mod.py').write(dedent("""\
+    package = tmpdir.mkdir("tmp_by_path_pkg")
+    package.join("__init__.py").ensure(file=True)
+    package.join("mod.py").write(
+        dedent(
+            """\
         class Foo(object):
             def sample(self):
                 return 1
-        """))
+        """
+        )
+    )
     sys.path.insert(0, six.text_type(tmpdir))
     patch_text = """\
         @@ -2,2 +2,2 @@
@@ -60,8 +64,9 @@ def test_patch_by_path(tmpdir):
         """
 
     try:
-        with patchy.temp_patch('tmp_by_path_pkg.mod.Foo.sample', patch_text):
+        with patchy.temp_patch("tmp_by_path_pkg.mod.Foo.sample", patch_text):
             from tmp_by_path_pkg.mod import Foo
+
             assert Foo().sample() == 2
     finally:
         sys.path.pop(0)

--- a/tests/test_unpatch.py
+++ b/tests/test_unpatch.py
@@ -8,12 +8,15 @@ def test_unpatch():
     def sample():
         return 9001
 
-    patchy.unpatch(sample, """\
+    patchy.unpatch(
+        sample,
+        """\
         @@ -1,2 +1,2 @@
          def sample():
         -    return 1
         +    return 9001
-        """)
+        """,
+    )
     assert sample() == 1
 
 
@@ -21,6 +24,7 @@ def test_unpatch_invalid_unreversed():
     """
     We need to balk on patches that fail on application
     """
+
     def sample():
         return 1
 
@@ -41,6 +45,7 @@ def test_unpatch_invalid_hunk():
     """
     We need to balk on patches that fail on application
     """
+
     def sample():
         return 1
 


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Run black on the code
* Add README badge