### PR TITLE
Tool expects unified diff, reflect that in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ How to Create a Patch
        def foo():
            print("Changed")
 
-3. Run ``diff``, e.g. ``diff before.py after.py``. You will get output like:
+3. Run ``diff``, e.g. ``diff -u before.py after.py``. You will get output like:
 
    .. code-block:: diff
 


### PR DESCRIPTION
Hi, I think patchy wants unified diff format, whereas `diff` produces 'normal' format by default, which patchy doesn't like.

P.S. Thanks for a great tool!