### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   - python: 3.8
   - python: 3.9-dev
 
-install: pip install tox-travis
+install: python -m pip install tox-travis
 
 script: tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -80,7 +80,7 @@ Ready to contribute? Here's how to set up `patchy` for local development.
     $ python setup.py test
     $ tox
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   To get flake8 and tox, just python -m pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Use **pip**:
 
 .. code-block:: bash
 
-    pip install patchy
+    python -m pip install patchy
 
 Python 3.5 to 3.8 supported.
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py38-codestyle
 
 [testenv]
-install_command = pip install --no-deps {opts} {packages}
+install_command = python -m pip install --no-deps {opts} {packages}
 commands = pytest {posargs}
 
 [testenv:py35]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).