### PR TITLE
Replace Codecov with Coverage-on-GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,12 +37,47 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade codecov tox tox-py
+        python -m pip install --upgrade tox tox-py
 
     - name: Run tox targets for ${{ matrix.python-version }}
       run: tox --py current
 
-    - name: Upload coverage
-      run: |
-        coverage combine
-        codecov
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-data
+        path: '.coverage.*'
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-20.04
+    needs: tests
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade coverage[toml]
+
+      - name: Download data
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-data
+
+      - name: Combine data
+        run: python -m coverage combine
+
+      - name: Generate HTML report
+        run: python -m coverage html --skip-covered --skip-empty
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-report
+          path: htmlcov
+
+      - name: Terminal report
+        run: python -m coverage report --fail-under=100

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Patchy
 .. image:: https://img.shields.io/github/workflow/status/adamchainz/patchy/CI/main?style=for-the-badge
    :target: https://github.com/adamchainz/patchy/actions?workflow=CI
 
-.. image:: https://img.shields.io/codecov/c/github/adamchainz/patchy/main?style=for-the-badge
-  :target: https://app.codecov.io/gh/adamchainz/patchy
+.. image:: https://img.shields.io/badge/Coverage-100%25-success?style=for-the-badge
+   :target: https://github.com/adamchainz/patchy/actions?workflow=CI
 
 .. image:: https://img.shields.io/pypi/v/patchy.svg?style=for-the-badge
    :target: https://pypi.org/project/patchy/


### PR DESCRIPTION
Thanks to Hynek Schlawack's post: https://hynek.me/til/ditch-codecov-python/