### PR TITLE
Tidy MANIFEST.in and remove check-manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,6 @@ repos:
     - flake8-comprehensions
     - flake8-tidy-imports
     - flake8-typing-imports
-- repo: https://github.com/mgedmin/check-manifest
-  rev: "0.48"
-  hooks:
-  - id: check-manifest
-    args: [--no-build-isolation]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.942
   hooks:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,3 @@
-global-exclude *.py[cod]
-prune __pycache__
-prune requirements
-prune tests
-exclude .editorconfig
-exclude .pre-commit-config.yaml
-exclude tox.ini
 include HISTORY.rst
 include LICENSE
 include pirate.png

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-license_file = LICENSE
 
 [options]
 package_dir=


### PR DESCRIPTION
Delete some unnecessary entries from MANIFEST.in which trigger warnings from setuptools, and remove check-manifest which requires these unnecessary entries. Should be fine without check-manifest as tox uses isolated builds now.
