### PR TITLE
Update setuptools config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
Remove wheel dependency and version number to match setuptools docs: 'https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use'

These were in the setuptools docs accidentally and later removed, as reported to Django in https://code.djangoproject.com/ticket/33778
