### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/patchy/api.py
+++ b/src/patchy/api.py
@@ -9,8 +9,13 @@ import sys
 from functools import wraps
 from tempfile import mkdtemp
 from textwrap import dedent
-from types import CodeType, TracebackType
-from typing import Any, Callable, Dict, TypeVar, cast
+from types import CodeType
+from types import TracebackType
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import TypeVar
 from weakref import WeakKeyDictionary
 
 from .cache import PatchingCache

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -6,7 +6,6 @@ from typing import Callable
 
 import pytest
 
-import patchy
 import patchy.api
 
 if True:

--- a/tests/test_patch_then_unpatch.py
+++ b/tests/test_patch_then_unpatch.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import patchy
 import patchy.api
 
 

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-import patchy
 import patchy.api
 
 

--- a/tests/test_temp_patch.py
+++ b/tests/test_temp_patch.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 from textwrap import dedent
 
-import patchy
 import patchy.api
 
 

--- a/tests/test_unpatch.py
+++ b/tests/test_unpatch.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-import patchy
 import patchy.api
 
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
