### PR TITLE
Make tests work with BSD patch messages

### DIFF
--- a/tests/test_unpatch.py
+++ b/tests/test_unpatch.py
@@ -60,5 +60,11 @@ def test_unpatch_invalid_hunk():
     with pytest.raises(ValueError) as excinfo:
         patchy.unpatch(sample, bad_patch)
 
-    assert "Hunk #1 FAILED" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert (
+        # GNU patch
+        "Hunk #1 FAILED" in msg
+        # BSD patch
+        or "1 out of 1 hunks failed" in msg
+    )
     assert sample() == 1


### PR DESCRIPTION
The new version from macOS seems to output different failure messages, so check for either.