### PR TITLE
Added [temp_]replace_substring

### DIFF
--- a/src/patchy/api.py
+++ b/src/patchy/api.py
@@ -28,7 +28,15 @@ if sys.version_info >= (3, 9):
 else:
     from pkgutil_resolve_name import resolve_name as pkgutil_resolve_name
 
-__all__ = ("patch", "mc_patchface", "unpatch", "replace", "temp_patch", "replace_substring", "temp_replace_substring")
+__all__ = (
+    "patch",
+    "mc_patchface",
+    "unpatch",
+    "replace",
+    "temp_patch",
+    "replace_substring",
+    "temp_replace_substring",
+)
 
 
 # Public API
@@ -101,7 +109,9 @@ class temp_patch:
 
 
 class temp_replace_substring:
-    def __init__(self, func: Callable[..., Any] | str, expected_source: str, new_source: str) -> None:
+    def __init__(
+        self, func: Callable[..., Any] | str, expected_source: str, new_source: str
+    ) -> None:
         self.func = func
         self.expected_source = expected_source
         self.new_source = new_source
@@ -389,7 +399,9 @@ def _assert_ast_equal(current_source: str, expected_source: str, name: str) -> N
         raise ValueError(msg)
 
 
-def _assert_substring_exists(current_source: str, expected_source: str, name: str) -> None:
+def _assert_substring_exists(
+    current_source: str, expected_source: str, name: str
+) -> None:
     if expected_source not in current_source:
         msg = (
             "The code of '{name}' does not include the expected substring.\n"

--- a/src/patchy/api.py
+++ b/src/patchy/api.py
@@ -75,8 +75,8 @@ def replace_substring(
     current_source = _get_source(func)
     if expected_source is not None:
         _assert_substring_exists(current_source, expected_source, func.__name__)
+        new_source = current_source.replace(expected_source, new_source)
 
-    new_source = current_source.replace(expected_source, new_source)
     _set_source(func, new_source)
 
 

--- a/tests/test_replace_substring.py
+++ b/tests/test_replace_substring.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+import patchy.api
+
+
+def test_replace_substring():
+    def sample() -> int:
+        return 1
+
+    assert sample() == 1
+
+    patchy.replace_substring(
+        sample,
+        """\
+            return 1
+        """,
+        """\
+            return 42
+        """,
+    )
+
+    assert sample() == 42
+
+
+def test_replace_substring_twice():
+    def sample() -> int:
+        return 1
+
+    assert sample() == 1
+
+    patchy.replace_substring(
+        sample, "return 1", "return 2"
+    )
+    patchy.replace_substring(
+        sample, "return 2", "return 3"
+    )
+
+    assert sample() == 3
+
+
+def test_replace_substring_mutable_default_arg():
+    def foo(append: str | None = None, mutable: list[str] = []) -> int:  # noqa: B006
+        if append is not None:
+            mutable.append(append)
+        return len(mutable)
+
+    assert foo() == 0
+    assert foo("v1") == 1
+    assert foo("v2") == 2
+    assert foo(mutable=[]) == 0
+
+    patchy.replace_substring(
+        foo,
+        """\
+            if append is not None:
+        """,
+        """\
+            len(mutable)
+            if append is not None:
+        """,
+    )
+
+    assert foo() == 2
+    assert foo("v3") == 3
+    assert foo(mutable=[]) == 0
+
+
+def test_replace_substring_instancemethod():
+    class Artist:
+        def method(self) -> str:
+            return "Chalk"
+
+    assert Artist().method() == "Chalk"
+
+    patchy.replace_substring(
+        Artist.method,
+        """\
+            return 'Chalk'
+        """,
+        """\
+            return 'Cheese'
+        """,
+    )
+
+    assert Artist().method() == "Cheese"
+
+
+def test_replace_substring_unexpected_source():
+    def sample() -> int:
+        return 2
+
+    assert sample() == 2
+
+    with pytest.raises(ValueError) as excinfo:
+        patchy.replace_substring(
+            sample,
+            """\
+                return 1
+            """,
+            """\
+                return 42
+            """,
+        )
+
+    msg = str(excinfo.value)
+    assert "The code of 'sample' has changed from expected" in msg
+    assert "return 2" in msg
+    assert "return 1" in msg
+
+
+def test_replace_substring_no_expected_source():
+    def sample() -> int:
+        return 2
+
+    assert sample() == 2
+
+    patchy.replace_substring(
+        sample,
+        None,
+        """\
+        def sample() -> int:
+            return 42
+        """,
+    )
+
+    assert sample() == 42

--- a/tests/test_replace_substring.py
+++ b/tests/test_replace_substring.py
@@ -30,12 +30,8 @@ def test_replace_substring_twice():
 
     assert sample() == 1
 
-    patchy.replace_substring(
-        sample, "return 1", "return 2"
-    )
-    patchy.replace_substring(
-        sample, "return 2", "return 3"
-    )
+    patchy.replace_substring(sample, "return 1", "return 2")
+    patchy.replace_substring(sample, "return 2", "return 3")
 
     assert sample() == 3
 

--- a/tests/test_temp_replace_substring.py
+++ b/tests/test_temp_replace_substring.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+from textwrap import dedent
+
+import patchy.api
+
+
+def test_context_manager():
+    def sample() -> int:
+        return 1234
+
+    assert sample() == 1234
+    with patchy.temp_replace_substring(sample, 'return 1234', 'return 5678'):
+        assert sample() == 5678
+    assert sample() == 1234
+
+
+def test_decorator():
+    def sample() -> int:
+        return 3456
+
+    @patchy.temp_replace_substring(sample, 'return 3456', 'return 7890')
+    def decorated() -> None:
+        assert sample() == 7890
+
+    assert sample() == 3456
+    decorated()
+    assert sample() == 3456
+
+
+def test_patch_by_path(tmp_path):
+    package = tmp_path / "tmp_by_path_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "mod.py").write_text(
+        dedent(
+            """\
+        class Foo(object):
+            def sample(self):
+                return 1
+        """
+        )
+    )
+    patch_text = """\
+        @@ -2,1 +2,1 @@
+        -    return 1
+        +    return 2
+        """
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        with patchy.temp_replace_substring("tmp_by_path_pkg.mod.Foo.sample", 'return 1', 'return 2'):
+            from tmp_by_path_pkg.mod import Foo
+
+            assert Foo().sample() == 2
+    finally:
+        sys.path.pop(0)
+
+    assert Foo().sample() == 1

--- a/tests/test_temp_replace_substring.py
+++ b/tests/test_temp_replace_substring.py
@@ -11,7 +11,7 @@ def test_context_manager():
         return 1234
 
     assert sample() == 1234
-    with patchy.temp_replace_substring(sample, 'return 1234', 'return 5678'):
+    with patchy.temp_replace_substring(sample, "return 1234", "return 5678"):
         assert sample() == 5678
     assert sample() == 1234
 
@@ -20,7 +20,7 @@ def test_decorator():
     def sample() -> int:
         return 3456
 
-    @patchy.temp_replace_substring(sample, 'return 3456', 'return 7890')
+    @patchy.temp_replace_substring(sample, "return 3456", "return 7890")
     def decorated() -> None:
         assert sample() == 7890
 
@@ -50,7 +50,9 @@ def test_patch_by_path(tmp_path):
 
     sys.path.insert(0, str(tmp_path))
     try:
-        with patchy.temp_replace_substring("tmp_by_path_pkg.mod.Foo.sample", 'return 1', 'return 2'):
+        with patchy.temp_replace_substring(
+            "tmp_by_path_pkg.mod.Foo.sample", "return 1", "return 2"
+        ):
             from tmp_by_path_pkg.mod import Foo
 
             assert Foo().sample() == 2


### PR DESCRIPTION
Added a new `replace_substring` method, which allows to replace any substring in the function code (literally using `str.replace()`. Also created accompanying context manager `temp_replace_substring`.